### PR TITLE
Support building on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "git2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazysort 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "qml 0.0.6 (git+https://github.com/White-Oak/qml-rust.git)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/White-Oak/architect"
 readme = "README.md"
 keywords = ["git", "stats", "qt", "statistics", "qml"]
 license = "Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 git2 = "*"
@@ -29,3 +30,6 @@ version = "*"
 default = ["cli"]
 cli = []
 qt = ["qml"]
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,106 @@
+extern crate pkg_config;
+
+use std::env;
+use std::env::consts;
+use std::path::PathBuf;
+
+fn find_qt5() {
+    /*
+     * Support Qt installed via the Ports system on BSD-like systems.
+     *
+     * The native libs are in `/usr/local/lib`, which is not linked against by default.
+     * This means that either the user or every package has to add this if they want to link
+     * against something that is not part of the core distribution in `/usr/lib`.
+     *
+     * See https://wiki.freebsd.org/WarnerLosh/UsrLocal for the line of reasoning & how this will
+     * change in the future.
+     */
+    if cfg!(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd",
+                target_os = "dragonfly", target_os = "bitrig")) {
+        println!("cargo:rustc-link-search=native=/usr/local/lib");
+    }
+
+    /*
+     * Parameters for supporting QT on OS X
+     *
+     * Because QT5 conflicts with QT4 the homebrew package manager won't link
+     * the QT5 package into the default search paths for libraries, to deal
+     * with this we need to give pkg-config and cmake a nudge in the right
+     * direction.
+     */
+    if cfg!(target_os = "macos") {
+        // We use the QTDIR or QTDIR64 env variables to find the location of
+        // Qt5. If these are not set, we use the default homebrew install
+        // location.
+        let qtdir_variable = match consts::ARCH {
+            "x86_64" => "QTDIR64",
+            _ => "QTDIR",
+        };
+        let mut qt5_lib_path = PathBuf::new();
+        qt5_lib_path.push(env::var(qtdir_variable).unwrap_or(String::from("/usr/local/opt/qt5")));
+        qt5_lib_path.push("lib");
+
+        if qt5_lib_path.exists() {
+            // First nudge cmake in the direction of the .cmake files added by
+            // homebrew. This clobbers the existing value if present, it's
+            // unlikely to be present though.
+            env::set_var("CMAKE_PREFIX_PATH", qt5_lib_path.join("cmake"));
+
+            // Nudge pkg-config in the direction of the brewed QT to ensure the
+            // correct compiler flags get found for the project.
+            env::set_var("PKG_CONFIG_PATH", qt5_lib_path.join("pkgconfig"));
+        } else {
+            panic!("QT5 was not found at the expected location ({}) please install it via homebrew, or set the {} env variable.",
+            qt5_lib_path.display(), qtdir_variable);
+        }
+    }
+
+    if cfg!(windows) {
+        let mut qt5_lib_path = PathBuf::new();
+        qt5_lib_path.push(env::var("QTDIR").unwrap_or(String::from("C:\\Qt\\5.7\\msvc2015_64")));
+
+        if qt5_lib_path.exists() {
+            env::set_var("CMAKE_PREFIX_PATH", &qt5_lib_path);
+
+            qt5_lib_path.push("lib");
+
+            println!("cargo:rustc-link-search=native={}\\system32",env::var("WINDIR").unwrap());
+            println!("cargo:rustc-link-search=native={}",qt5_lib_path.display());
+
+            println!("cargo:rustc-link-lib=dylib=Qt5Core");
+            println!("cargo:rustc-link-lib=dylib=Qt5Gui");
+            println!("cargo:rustc-link-lib=dylib=Qt5Qml");
+            println!("cargo:rustc-link-lib=dylib=Qt5Quick");
+            println!("cargo:rustc-link-lib=dylib=Qt5Svg");
+            println!("cargo:rustc-link-lib=dylib=Qt5Widgets");
+        } else {
+            panic!("QT5 was not found at the expected location ({}) please install the SDK or set the QTDIR env variable.",
+            qt5_lib_path.display());
+        }
+    } else {
+        use pkg_config;
+
+        if cfg!(any(target_os = "macos", target_os = "freebsd", target_os = "bitrig")) {
+            println!("cargo:rustc-link-lib=dylib=c++");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=stdc++");
+        }
+
+        match pkg_config::find_library("Qt5Core Qt5Gui Qt5Qml Qt5Quick Qt5Svg") {
+            Ok(lib) => {
+                for p in lib.link_paths { println!("cargo:rustc-link-search=native={}",p.display()); }
+                for p in lib.libs { println!("cargo:rustc-link-lib=dylib={}",p); }
+                if cfg!(target_os = "macos") {
+                    for p in lib.framework_paths { println!("cargo:rustc-link-search=framework={}",p.display()); }
+                    for p in lib.frameworks { println!("cargo:rustc-link-lib=framework={}",p); }
+                }
+                for p in lib.include_paths { println!("cargo:include={}",p.display()); }
+            }
+            Err(e) => panic!("QT5 was not found using pkg-config: {}",e)
+        }
+    }
+}
+
+fn main() {
+    find_qt5();
+}


### PR DESCRIPTION
This takes the build.rs as found in the qml-rust repo and removes
everything except the logic for locating Qt, and then wires it up in the
Cargo.toml file.